### PR TITLE
Adds support for animations as 3-D pixel arrays

### DIFF
--- a/mudicom/image.py
+++ b/mudicom/image.py
@@ -67,9 +67,13 @@ class Image(object):
             gdcm_array = gdcm_array.encode(sys.getfilesystemencoding(), "surrogateescape")
 
         # use float for accurate scaling
-        result = numpy.frombuffer(gdcm_array,
-            dtype=self.data_type).astype(float)
-        result.shape = self.dimensions
+        dimensions = image.GetDimensions()
+        result = numpy.frombuffer(gdcm_array, dtype=self.data_type).astype(float)
+        if len(dimensions) == 3:
+            # for cine (animations) there are 3 dims: x, y, number of frames
+            result.shape = dimensions[2], dimensions[0], dimensions[1]
+        else:
+            result.shape = dimensions
         return result
 
     def save_as_plt(self, fname, pixel_array=None, vmin=None, vmax=None,

--- a/mudicom/tests/test_image.py
+++ b/mudicom/tests/test_image.py
@@ -8,15 +8,22 @@ import mudicom
 
 class TestImage(unittest.TestCase):
 
-	def setUp(self):
-		nose_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "dicoms")
-		self.fnames = (os.path.join(nose_dir, "ex1.dcm"),
-			os.path.join(nose_dir, "ex2.dcm"),)
+    def setUp(self):
+        nose_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "dicoms")
+        self.fnames = (os.path.join(nose_dir, "ex1.dcm"),
+                       os.path.join(nose_dir, "ex2.dcm"),
+                       os.path.join(nose_dir, "ex3.dcm"),)
 
-	def test_get_numpy(self):
-		for fname in self.fnames:
-			mu = mudicom.load(fname)
-			img = mu.image
-			gnp = img.numpy
-			self.assertIsInstance(gnp, numpy.ndarray)
-			self.assertEqual(gnp.dtype, numpy.float)
+    def test_get_numpy(self):
+        for fname in self.fnames:
+            mu = mudicom.load(fname)
+            img = mu.image
+            gnp = img.numpy
+            self.assertIsInstance(gnp, numpy.ndarray)
+            self.assertEqual(gnp.dtype, numpy.float)
+
+    def test_animation_numpy_shape(self):
+        mu = mudicom.load(self.fnames[2])
+        image = mu.image
+        self.assertEqual(len(image.numpy.shape), 3)
+        self.assertEqual(image.numpy.shape[0], 76)


### PR DESCRIPTION
When the DICOM image has animation frames, the original method will fail. `gdcm.Image.GetDimensions` will return 3-dimensions instead of 2 when there are animation frames, and the interpretation is: (x, y, frame count)

This change reshapes the numpy array to be a 3-dimensional array when there are animation frames, otherwise it will return the normal 2-dimensional arrays.